### PR TITLE
Remove access key from interpreters

### DIFF
--- a/backlog4s-akka/src/main/scala/backlog4s/interpreters/AkkaHttpInterpret.scala
+++ b/backlog4s-akka/src/main/scala/backlog4s/interpreters/AkkaHttpInterpret.scala
@@ -22,8 +22,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-class AkkaHttpInterpret(baseUrl: String, credentials: Credentials)
-                       (implicit actorSystem: ActorSystem, mat: Materializer,
+class AkkaHttpInterpret(implicit actorSystem: ActorSystem, mat: Materializer,
                         exc: ExecutionContext) extends BacklogHttpInterpret[Future] {
 
 
@@ -39,16 +38,16 @@ class AkkaHttpInterpret(baseUrl: String, credentials: Credentials)
   )
 
   private def createRequest(method: HttpMethod, query: HttpQuery): HttpRequest =
-    credentials match {
+    query.credentials match {
       case AccessKey(key) =>
         HttpRequest(
           method = method,
-          uri = Uri(baseUrl + query.path).withQuery(Query(query.params + ("apiKey" -> key))),
+          uri = Uri(query.baseUrl + query.path).withQuery(Query(query.params + ("apiKey" -> key))),
         ).withHeaders(reqHeaders)
       case OAuth2Token(token) =>
         HttpRequest(
           method = method,
-          uri = Uri(baseUrl + query.path).withQuery(Query(query.params))
+          uri = Uri(query.baseUrl + query.path).withQuery(Query(query.params))
         ).withHeaders(
           reqHeaders :+
             headers.Authorization(OAuth2BearerToken(token))

--- a/backlog4s-core/src/main/scala/backlog4s/apis/ActivityApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/ActivityApi.scala
@@ -1,23 +1,34 @@
 package backlog4s.apis
 
-import backlog4s.datas.{Activity, Id, User}
+import backlog4s.datas._
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object ActivityApi {
+class ActivityApi(override val baseUrl: String,
+                  override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def user(id: Id[User]): ApiPrg[Response[Seq[Activity]]] =
     get[Seq[Activity]](
       HttpQuery(
-        s"users/${id.value}/activities"
+        path = s"users/${id.value}/activities",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def space: ApiPrg[Response[Seq[Activity]]] =
     get[Seq[Activity]](
-      HttpQuery("space/activities")
+      HttpQuery(
+        path = "space/activities",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
+}
+object ActivityApi extends ApiContext[ActivityApi] {
+  override def apply(baseUrl: String, credentials: Credentials): ActivityApi =
+    new ActivityApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/AllApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/AllApi.scala
@@ -1,0 +1,35 @@
+package backlog4s.apis
+
+import backlog4s.datas.Credentials
+
+class AllApi(override val baseUrl: String,
+             override val credentials: Credentials) extends Api {
+
+  lazy val activityApi = ActivityApi(baseUrl, credentials)
+  lazy val attachmentApi = AttachmentApi(baseUrl, credentials)
+  lazy val categoryApi = CategoryApi(baseUrl, credentials)
+  lazy val gitApi = GitApi(baseUrl, credentials)
+  lazy val groupApi = GroupApi(baseUrl, credentials)
+  lazy val issueApi = IssueApi(baseUrl, credentials)
+  lazy val issueCommentApi = IssueCommentApi(baseUrl, credentials)
+  lazy val issueTypeApi = IssueTypeApi(baseUrl, credentials)
+  lazy val milestoneApi = MilestoneApi(baseUrl, credentials)
+  lazy val notificationApi = NotificationApi(baseUrl, credentials)
+  lazy val priorityApi = PriorityApi(baseUrl, credentials)
+  lazy val projectApi = ProjectApi(baseUrl, credentials)
+  lazy val pullRequestCommentApi = PullRequestCommentApi(baseUrl, credentials)
+  lazy val resolutionApi = ResolutionApi(baseUrl, credentials)
+  lazy val sharedFileApi = SharedFileApi(baseUrl, credentials)
+  lazy val spaceApi = SpaceApi(baseUrl, credentials)
+  lazy val starApi = StarApi(baseUrl, credentials)
+  lazy val statusApi = StatusApi(baseUrl, credentials)
+  lazy val userApi = UserApi(baseUrl, credentials)
+  lazy val watchingApi = WatchingApi(baseUrl, credentials)
+  lazy val webhookApi = WebhookApi(baseUrl, credentials)
+  lazy val wikiApi = WikiApi(baseUrl, credentials)
+}
+
+object AllApi extends ApiContext[AllApi] {
+  override def apply(baseUrl: String, credentials: Credentials): AllApi =
+    new AllApi(baseUrl, credentials)
+}

--- a/backlog4s-core/src/main/scala/backlog4s/apis/Api.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/Api.scala
@@ -1,0 +1,16 @@
+package backlog4s.apis
+
+import backlog4s.datas.{AccessKey, Credentials, OAuth2Token}
+
+trait Api {
+  def credentials: Credentials
+  def baseUrl: String
+}
+
+trait ApiContext[A <: Api] {
+  def apply(baseUrl: String, credentials: Credentials): A
+  def accessKey(baseUrl: String, accessKey: String): A =
+    apply(baseUrl, AccessKey(accessKey))
+  def oauthToken(baseUrl: String, token: String): A =
+    apply(baseUrl, OAuth2Token(token))
+}

--- a/backlog4s-core/src/main/scala/backlog4s/apis/AttachmentApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/AttachmentApi.scala
@@ -1,18 +1,29 @@
 package backlog4s.apis
 
 import java.io.File
-import backlog4s.datas.Attachment
+
+import backlog4s.datas.{AccessKey, Attachment, Credentials, OAuth2Token}
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object AttachmentApi {
+class AttachmentApi(override val baseUrl: String,
+                    override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def send(file: File): ApiPrg[Response[Attachment]] =
     upload[Attachment](
-      HttpQuery("space/attachment"),
+      HttpQuery(
+        path = "space/attachment",
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       file
     )
+}
+
+object AttachmentApi extends ApiContext[AttachmentApi] {
+  override def apply(baseUrl: String, credentials: Credentials): AttachmentApi =
+    new AttachmentApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/CategoryApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/CategoryApi.scala
@@ -1,13 +1,14 @@
 package backlog4s.apis
 
 import backlog4s.datas.CustomForm.CustomForm
-import backlog4s.datas.{Category, Id, IdOrKeyParam, Project}
+import backlog4s.datas._
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object CategoryApi {
+class CategoryApi(override val baseUrl: String,
+                  override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def resource(projectIdOrKey: IdOrKeyParam[Project]): String =
@@ -15,12 +16,20 @@ object CategoryApi {
 
   def allOf(projectIdOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Seq[Category]]] =
     get[Seq[Category]](
-      HttpQuery(resource(projectIdOrKey))
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def add(projectIdOrKey: IdOrKeyParam[Project], name: String): ApiPrg[Response[Category]] =
     post[CustomForm, Category](
-      HttpQuery(resource(projectIdOrKey)),
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       Map(
         "name" -> name
       )
@@ -31,7 +40,9 @@ object CategoryApi {
              newName: String): ApiPrg[Response[Category]] =
     put[CustomForm, Category](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/${id.value}"
+        path = s"${resource(projectIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       Map(
         "name" -> newName
@@ -41,6 +52,15 @@ object CategoryApi {
   def remove(projectIdOrKey: IdOrKeyParam[Project],
              id: Id[Category]): ApiPrg[Response[Unit]] =
     delete(
-      HttpQuery(s"${resource(projectIdOrKey)}/${id.value}")
+      HttpQuery(
+        path = s"${resource(projectIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
+}
+
+object CategoryApi extends ApiContext[CategoryApi] {
+  override def apply(baseUrl: String, credentials: Credentials): CategoryApi =
+    new CategoryApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/GitApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/GitApi.scala
@@ -6,7 +6,8 @@ import backlog4s.dsl.HttpADT.{ByteStream, Response}
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object GitApi {
+class GitApi(override val baseUrl: String,
+             override val credentials: Credentials) extends Api {
 
   import backlog4s.dsl.ApiDsl.HttpOp._
 
@@ -15,14 +16,20 @@ object GitApi {
 
   def allOf(projectIdOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Seq[GitRepository]]] =
     get[Seq[GitRepository]](
-      HttpQuery(resource(projectIdOrKey))
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def byIdOrName(projectIdOrKey: IdOrKeyParam[Project],
                  repoIdOrName: IdOrKeyParam[GitRepository]): ApiPrg[Response[GitRepository]] =
     get[GitRepository](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -30,7 +37,9 @@ object GitApi {
                    repoIdOrName: IdOrKeyParam[GitRepository]): ApiPrg[Response[Seq[PullRequestSummary]]] =
     get[Seq[PullRequestSummary]](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -38,7 +47,9 @@ object GitApi {
                         repoIdOrName: IdOrKeyParam[GitRepository]): ApiPrg[Response[Count]] =
     get[Count](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/count"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/count",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -47,7 +58,9 @@ object GitApi {
                   pullRequestNumber: Long): ApiPrg[Response[PullRequest]] =
     get[PullRequest](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -56,7 +69,9 @@ object GitApi {
                         form: AddPullRequestForm): ApiPrg[Response[PullRequest]] =
     post[AddPullRequestForm, PullRequest](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -67,7 +82,9 @@ object GitApi {
                         form: UpdatePullRequestForm): ApiPrg[Response[PullRequest]] =
     put[UpdatePullRequestForm, PullRequest](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -77,7 +94,9 @@ object GitApi {
                   pullRequestNumber: Long): ApiPrg[Response[Seq[Attachment]]] =
     get[Seq[Attachment]](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber/attachments"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber/attachments",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -87,7 +106,9 @@ object GitApi {
                          attachmentId: Id[Attachment]): ApiPrg[Response[ByteStream]] =
     download(
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber/attachments/${attachmentId.value}"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber/attachments/${attachmentId.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -97,8 +118,15 @@ object GitApi {
                        attachmentId: Id[Attachment]): ApiPrg[Response[Unit]] =
     delete(
       HttpQuery(
-        s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber/attachments/${attachmentId.value}"
+        path = s"${resource(projectIdOrKey)}/$repoIdOrName/pullRequests/$pullRequestNumber/attachments/${attachmentId.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
+}
+
+object GitApi extends ApiContext[GitApi] {
+  override def apply(baseUrl: String, credentials: Credentials): GitApi =
+    new GitApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/GroupApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/GroupApi.scala
@@ -7,7 +7,8 @@ import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object GroupApi {
+class GroupApi(override val baseUrl: String,
+               override val credentials: Credentials) extends Api {
   private val resource = "groups"
 
   import backlog4s.dsl.ApiDsl.HttpOp._
@@ -15,27 +16,58 @@ object GroupApi {
   def all(offset: Int = 0,
           limit: Int = 100,
           order: Order = Order.Desc): ApiPrg[Response[Seq[Group]]] =
-    get[Seq[Group]](HttpQuery(s"$resource", Map(
-      "offset" -> offset.toString,
-      "count" -> limit.toString,
-      "order" -> order.toString
-    )))
+    get[Seq[Group]](
+      HttpQuery(
+        s"$resource",
+        Map(
+          "offset" -> offset.toString,
+          "count" -> limit.toString,
+          "order" -> order.toString
+        ),
+        credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def byId(id: Id[Group]): ApiPrg[Response[Group]] =
-    get[Group](HttpQuery(s"$resource/${id.value}"))
+    get[Group](
+      HttpQuery(
+        path = s"$resource/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def create(addGroupForm: AddGroupForm): ApiPrg[Response[Group]] =
     post[AddGroupForm, Group](
-      HttpQuery(resource),
+      HttpQuery(
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       addGroupForm
     )
 
   def update(updateGroupForm: UpdateGroupForm): ApiPrg[Response[Group]] =
     put[UpdateGroupForm, Group](
-      HttpQuery(resource),
+      HttpQuery(
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       updateGroupForm
     )
 
   def remove(id: Id[Group]): ApiPrg[Response[Unit]] =
-    delete(HttpQuery(s"$resource/${id.value}"))
+    delete(
+      HttpQuery(
+        path = s"$resource/${id.value}", credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
+}
+
+object GroupApi extends ApiContext[GroupApi] {
+  override def apply(baseUrl: String, credentials: Credentials): GroupApi =
+    new GroupApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/IssueCommentApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/IssueCommentApi.scala
@@ -9,7 +9,8 @@ import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 import backlog4s.utils.QueryParameter
 
-object IssueCommentApi {
+class IssueCommentApi(override val baseUrl: String,
+                      override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def resource(issueIdOrKey: IdOrKeyParam[Issue]): String =
@@ -30,24 +31,38 @@ object IssueCommentApi {
     get[Seq[Comment]](
       HttpQuery(
         resource(issueIdOrKey),
-        QueryParameter.removeEmptyValue(params)
+        QueryParameter.removeEmptyValue(params),
+        credentials,
+        baseUrl
       )
     )
   }
 
   def count(issueIdOrKey: IdOrKeyParam[Issue]): ApiPrg[Response[Count]] =
     get[Count](
-      HttpQuery(s"${resource(issueIdOrKey)}/count)")
+      HttpQuery(
+        path = s"${resource(issueIdOrKey)}/count)",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def getById(issueIdOrKey: IdOrKeyParam[Issue], id: Id[Comment]): ApiPrg[Response[Comment]] =
     get[Comment](
-      HttpQuery(s"${resource(issueIdOrKey)}/${id.value}")
+      HttpQuery(
+        path = s"${resource(issueIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def add(issueIdOrKey: IdOrKeyParam[Issue], form: AddCommentForm): ApiPrg[Response[Comment]] =
     post[AddCommentForm, Comment](
-      HttpQuery(resource(issueIdOrKey)),
+      HttpQuery(
+        path = resource(issueIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       form
     )
 
@@ -55,7 +70,11 @@ object IssueCommentApi {
              id: Id[Comment],
              newContent: String): ApiPrg[Response[Comment]] =
     put[CustomForm, Comment](
-      HttpQuery(s"${resource(issueIdOrKey)}/${id.value}"),
+      HttpQuery(
+        path = s"${resource(issueIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       Map(
         "content" -> newContent
       )
@@ -63,7 +82,11 @@ object IssueCommentApi {
 
   def notifications(issueIdOrKey: IdOrKeyParam[Issue], id: Id[Comment]): ApiPrg[Response[Seq[Notification]]] =
     get[Seq[Notification]](
-      HttpQuery(s"${resource(issueIdOrKey)}/${id.value}/notifications")
+      HttpQuery(
+        path = s"${resource(issueIdOrKey)}/${id.value}/notifications",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def addNotification(issueIdOrKey: IdOrKeyParam[Issue],
@@ -71,8 +94,15 @@ object IssueCommentApi {
                       form: AddNotificationForm): ApiPrg[Response[Comment]] =
     post[AddNotificationForm, Comment](
       HttpQuery(
-        s"${resource(issueIdOrKey)}/${id.value}/notifications"
+        path = s"${resource(issueIdOrKey)}/${id.value}/notifications",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
+}
+
+object IssueCommentApi extends ApiContext[IssueCommentApi] {
+  override def apply(baseUrl: String, credentials: Credentials): IssueCommentApi =
+    new IssueCommentApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/IssueTypeApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/IssueTypeApi.scala
@@ -7,7 +7,8 @@ import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object IssueTypeApi {
+class IssueTypeApi(override val baseUrl: String,
+                   override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def resource(projectIdOrKey: IdOrKeyParam[Project]): String =
@@ -15,12 +16,20 @@ object IssueTypeApi {
 
   def allOf(projectIdOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Seq[IssueType]]] =
     get[Seq[IssueType]](
-      HttpQuery(resource(projectIdOrKey))
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def add(projectIdOrKey: IdOrKeyParam[Project], color: RGBColor): ApiPrg[Response[IssueType]] =
     post[CustomForm, IssueType](
-      HttpQuery(resource(projectIdOrKey)),
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       Map(
         "color" -> color.toHex
       )
@@ -30,12 +39,25 @@ object IssueTypeApi {
              id: Id[IssueType],
              form: UpdateIssueTypeForm): ApiPrg[Response[IssueType]] =
     put[UpdateIssueTypeForm, IssueType](
-      HttpQuery(s"${resource(projectIdOrKey)}/${id.value}"),
+      HttpQuery(
+        path = s"${resource(projectIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       form
     )
 
   def remove(projectIdOrKey: IdOrKeyParam[Project], id: Id[IssueType]): ApiPrg[Response[Unit]] =
     delete(
-      HttpQuery(s"${resource(projectIdOrKey)}/${id.value}")
+      HttpQuery(
+        path = s"${resource(projectIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
+}
+
+object IssueTypeApi extends ApiContext[IssueTypeApi] {
+  override def apply(baseUrl: String, credentials: Credentials): IssueTypeApi =
+    new IssueTypeApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/MilestoneApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/MilestoneApi.scala
@@ -6,7 +6,8 @@ import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object MilestoneApi {
+class MilestoneApi(override val baseUrl: String,
+                   override val credentials: Credentials) extends Api{
 
   import backlog4s.dsl.ApiDsl.HttpOp._
 
@@ -15,13 +16,21 @@ object MilestoneApi {
 
   def allOf(projectIdOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Seq[Milestone]]] =
     get[Seq[Milestone]](
-      HttpQuery(resource(projectIdOrKey))
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def add(projectIdOrKey: IdOrKeyParam[Project],
           form: AddMilestoneForm): ApiPrg[Response[Milestone]] =
     post[AddMilestoneForm, Milestone](
-      HttpQuery(resource(projectIdOrKey)),
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       form
     )
 
@@ -29,12 +38,25 @@ object MilestoneApi {
              id: Id[Milestone],
              form: UpdateMilestoneForm): ApiPrg[Response[Milestone]] =
     put[UpdateMilestoneForm, Milestone](
-      HttpQuery(resource(projectIdOrKey)),
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       form
     )
 
   def remove(projectIdOrKey: IdOrKeyParam[Project], id: Id[Milestone]): ApiPrg[Response[Unit]] =
     delete(
-      HttpQuery(s"${resource(projectIdOrKey)}/${id.value}")
+      HttpQuery(
+        path = s"${resource(projectIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
+}
+
+object MilestoneApi extends ApiContext[MilestoneApi] {
+  override def apply(baseUrl: String, credentials: Credentials): MilestoneApi =
+    new MilestoneApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/NotificationApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/NotificationApi.scala
@@ -3,14 +3,15 @@ package backlog4s.apis
 import backlog4s.datas.CustomForm.CustomForm
 import backlog4s.datas.NoContent.NoContent
 import backlog4s.datas.Order.Order
-import backlog4s.datas.{Count, Id, Notification, Order}
+import backlog4s.datas._
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.utils.QueryParameter
 import backlog4s.formatters.SprayJsonFormats._
 
-object NotificationApi {
+class NotificationApi(override val baseUrl: String,
+                      override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   val resource = "notifications"
@@ -28,7 +29,9 @@ object NotificationApi {
     get[Seq[Notification]](
       HttpQuery(
         resource,
-        QueryParameter.removeEmptyValue(params)
+        QueryParameter.removeEmptyValue(params),
+        credentials,
+        baseUrl
       )
     )
   }
@@ -42,7 +45,9 @@ object NotificationApi {
     get[Count](
       HttpQuery(
         s"$resource/count",
-        QueryParameter.removeEmptyValue(params)
+        QueryParameter.removeEmptyValue(params),
+        credentials,
+        baseUrl
       )
     )
   }
@@ -50,7 +55,9 @@ object NotificationApi {
   def markAllAsRead: ApiPrg[Response[Count]] =
     post[CustomForm, Count](
       HttpQuery(
-        s"$resource/markAsRead"
+        path = s"$resource/markAsRead",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       Map()
     )
@@ -58,8 +65,15 @@ object NotificationApi {
   def read(id: Id[Notification]): ApiPrg[Response[NoContent]] =
     post[CustomForm, NoContent](
       HttpQuery(
-        s"notifications/${id.value}/markAsRead"
+        path = s"notifications/${id.value}/markAsRead",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       Map()
     )
+}
+
+object NotificationApi extends ApiContext[NotificationApi] {
+  override def apply(baseUrl: String, credentials: Credentials): NotificationApi =
+    new NotificationApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/PriorityApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/PriorityApi.scala
@@ -1,17 +1,29 @@
 package backlog4s.apis
 
-import backlog4s.datas.{Priority, Resolution}
+import backlog4s.datas.{Credentials, Priority, Resolution}
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object PriorityApi {
+class PriorityApi(override val baseUrl: String,
+                  override val credentials: Credentials) extends Api {
 
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   val resource = "priorities"
 
   def all: ApiPrg[Response[Seq[Priority]]] =
-    get[Seq[Priority]](HttpQuery(resource))
+    get[Seq[Priority]](
+      HttpQuery(
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
+}
+
+object PriorityApi extends ApiContext[PriorityApi] {
+  override def apply(baseUrl: String, credentials: Credentials): PriorityApi =
+    new PriorityApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/ProjectApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/ProjectApi.scala
@@ -8,7 +8,8 @@ import backlog4s.dsl.HttpADT.{ByteStream, Response}
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object ProjectApi {
+class ProjectApi(override val baseUrl: String,
+                 override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   private val resource = "projects"
@@ -27,34 +28,67 @@ object ProjectApi {
       "all" -> all.toString
     ))
 
-    get[Seq[Project]](HttpQuery(resource, params))
+    get[Seq[Project]](HttpQuery(resource, params, credentials, baseUrl))
   }
 
   def byIdOrKey(idOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Project]] =
-    get[Project](HttpQuery(s"$resource/$idOrKey"))
+    get[Project](
+      HttpQuery(
+        path = s"$resource/$idOrKey",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def admins(idOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Seq[User]]] =
-    get[Seq[User]](HttpQuery(s"$resource/$idOrKey/administrators"))
+    get[Seq[User]](
+      HttpQuery(
+        path = s"$resource/$idOrKey/administrators",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def users(idOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Seq[User]]] =
-    get[Seq[User]](HttpQuery(s"$resource/$idOrKey/users"))
+    get[Seq[User]](
+      HttpQuery(
+        path = s"$resource/$idOrKey/users",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def icon(idOrKey: IdOrKeyParam[Project]): ApiPrg[Response[ByteStream]] =
-    download(HttpQuery(s"$resource/$idOrKey/image"))
+    download(
+      HttpQuery(
+        path = s"$resource/$idOrKey/image",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def recentlyViewed(order: Order = Order.Desc): ApiPrg[Response[Seq[Project]]] =
     get[Seq[Project]](
       HttpQuery(
-        "users/myself/recentlyViewedProjects"
+        path = "users/myself/recentlyViewedProjects",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def create(addProjectForm: AddProjectForm): ApiPrg[Response[Project]] =
-    post[AddProjectForm, Project](HttpQuery(resource), addProjectForm)
+    post[AddProjectForm, Project](
+      HttpQuery(path = resource, credentials = credentials, baseUrl = baseUrl),
+      addProjectForm
+    )
 
   def addAdmin(idOrKey: IdOrKeyParam[Project], userId: Id[User]): ApiPrg[Response[User]] =
     post[CustomForm, User](
-      HttpQuery(s"$resource/$idOrKey/administrators"),
+      HttpQuery(
+        path = s"$resource/$idOrKey/administrators",
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       Map(
         "userId" -> userId.value.toString
       )
@@ -65,13 +99,17 @@ object ProjectApi {
       path = s"$resource/$idOrKey/administrators",
       params = Map(
         "userId" -> userId.value.toString
-      )
+      ),
+      credentials = credentials,
+      baseUrl = baseUrl
     ))
 
   def addUser(idOrKey: IdOrKeyParam[Project], userId: Id[User]): ApiPrg[Response[User]] =
     post[CustomForm, User](
       HttpQuery(
-        s"$resource/$idOrKey/users"
+        path = s"$resource/$idOrKey/users",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       Map(
         "userId" -> userId.toString
@@ -84,12 +122,24 @@ object ProjectApi {
         path = s"$resource/$idOrKey/users",
         params = Map(
           "userId" -> userId.value.toString
-        )
+        ),
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def update(idOrKey: IdOrKeyParam[Project], form: UpdateProjectForm): ApiPrg[Response[Project]] =
     put[UpdateProjectForm, Project](
-      HttpQuery(s"$resource/$idOrKey"), form
+      HttpQuery(
+        path = s"$resource/$idOrKey",
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
+      form
     )
+}
+
+object ProjectApi extends ApiContext[ProjectApi] {
+  override def apply(baseUrl: String, credentials: Credentials): ProjectApi =
+    new ProjectApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/PullRequestCommentApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/PullRequestCommentApi.scala
@@ -7,7 +7,8 @@ import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object PullRequestCommentApi {
+class PullRequestCommentApi(override val baseUrl: String,
+                            override val credentials: Credentials) extends Api {
 
   import backlog4s.dsl.ApiDsl.HttpOp._
 
@@ -21,7 +22,9 @@ object PullRequestCommentApi {
                pullRequestNumber: Long): ApiPrg[Response[Seq[Comment]]] =
     get[Seq[Comment]](
       HttpQuery(
-        resource(projectIdOrKey, repoIdOrName, pullRequestNumber)
+        path = resource(projectIdOrKey, repoIdOrName, pullRequestNumber),
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -29,7 +32,11 @@ object PullRequestCommentApi {
             repoIdOrName: IdOrKeyParam[GitRepository],
             pullRequestNumber: Long): ApiPrg[Response[Count]] =
     get[Count](
-      HttpQuery(s"${resource(projectIdOrKey, repoIdOrName, pullRequestNumber)}/count")
+      HttpQuery(
+        path = s"${resource(projectIdOrKey, repoIdOrName, pullRequestNumber)}/count",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def postComment(projectIdOrKey: IdOrKeyParam[Project],
@@ -38,7 +45,9 @@ object PullRequestCommentApi {
                   form: AddCommentForm): ApiPrg[Response[Comment]] =
     post[AddCommentForm, Comment](
       HttpQuery(
-        resource(projectIdOrKey, repoIdOrName, pullRequestNumber)
+        path = resource(projectIdOrKey, repoIdOrName, pullRequestNumber),
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -50,10 +59,17 @@ object PullRequestCommentApi {
                   newContent: String): ApiPrg[Response[Comment]] =
     put[CustomForm, Comment](
       HttpQuery(
-        s"${resource(projectIdOrKey, repoIdOrName, pullRequestNumber)}/${commentId.value}"
+        path = s"${resource(projectIdOrKey, repoIdOrName, pullRequestNumber)}/${commentId.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       Map(
         "content" -> newContent
       )
     )
+}
+
+object PullRequestCommentApi extends ApiContext[PullRequestCommentApi] {
+  override def apply(baseUrl: String, credentials: Credentials): PullRequestCommentApi =
+    new PullRequestCommentApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/ResolutionApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/ResolutionApi.scala
@@ -1,17 +1,29 @@
 package backlog4s.apis
 
-import backlog4s.datas.Resolution
+import backlog4s.datas.{Credentials, Resolution}
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object ResolutionApi {
+class ResolutionApi(override val baseUrl: String,
+                    override val credentials: Credentials) extends Api {
 
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   val resource = "resolutions"
 
   def all: ApiPrg[Response[Seq[Resolution]]] =
-    get[Seq[Resolution]](HttpQuery(resource))
+    get[Seq[Resolution]](
+      HttpQuery(
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
+}
+
+object ResolutionApi extends ApiContext[ResolutionApi] {
+  override def apply(baseUrl: String, credentials: Credentials): ResolutionApi =
+    new ResolutionApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/SharedFileApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/SharedFileApi.scala
@@ -8,7 +8,8 @@ import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 import cats.data.NonEmptyList
 
-object SharedFileApi {
+class SharedFileApi(override val baseUrl: String,
+                    override val credentials: Credentials) extends Api{
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def allOf(projectIdOrKey: IdOrKeyParam[Project],
@@ -17,6 +18,15 @@ object SharedFileApi {
             offset: Long = 0,
             count: Long = 20): ApiPrg[Response[Seq[SharedFile]]] =
     get[Seq[SharedFile]](
-      HttpQuery(s"projects/$projectIdOrKey/files/metadata/$path")
+      HttpQuery(
+        path = s"projects/$projectIdOrKey/files/metadata/$path",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
+}
+
+object SharedFileApi extends ApiContext[SharedFileApi] {
+  override def apply(baseUrl: String, credentials: Credentials): SharedFileApi =
+    new SharedFileApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/SpaceApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/SpaceApi.scala
@@ -1,25 +1,55 @@
 package backlog4s.apis
 
-import backlog4s.datas.{Space, SpaceDiskUsage, SpaceNotification}
+import backlog4s.datas.{Credentials, Space, SpaceDiskUsage, SpaceNotification}
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.{ByteStream, Response}
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object SpaceApi {
+class SpaceApi(override val baseUrl: String,
+               override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   val resource = "space"
 
   def current: ApiPrg[Response[Space]] =
-    get[Space](HttpQuery(s"$resource"))
+    get[Space](
+      HttpQuery(
+        path = s"$resource",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def logo: ApiPrg[Response[ByteStream]] =
-    download(HttpQuery(s"$resource/image"))
+    download(
+      HttpQuery(
+        path = s"$resource/image",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def notification: ApiPrg[Response[SpaceNotification]] =
-    get[SpaceNotification](HttpQuery(s"$resource/notification"))
+    get[SpaceNotification](
+      HttpQuery(
+        path = s"$resource/notification",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def diskUsage: ApiPrg[Response[SpaceDiskUsage]] =
-    get[SpaceDiskUsage](HttpQuery(s"$resource/diskUsage"))
+    get[SpaceDiskUsage](
+      HttpQuery(
+        path = s"$resource/diskUsage",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
+}
+
+object SpaceApi extends ApiContext[SpaceApi] {
+  override def apply(baseUrl: String, credentials: Credentials): SpaceApi =
+    new SpaceApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/StarApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/StarApi.scala
@@ -10,7 +10,8 @@ import org.joda.time.DateTime
 import backlog4s.formatters.SprayJsonFormats._
 import backlog4s.utils.QueryParameter
 
-object StarApi {
+class StarApi(override val baseUrl: String,
+              override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def user(id: Id[User],
@@ -28,7 +29,9 @@ object StarApi {
     get[Seq[Star]](
       HttpQuery(
         s"users/${id.value}/stars",
-        QueryParameter.removeEmptyValue(params)
+        QueryParameter.removeEmptyValue(params),
+        credentials,
+        baseUrl
       )
     )
   }
@@ -48,14 +51,21 @@ object StarApi {
     get[Count](
       HttpQuery(
         s"users/${id.value}/stars/count",
-        QueryParameter.removeEmptyValue(params)
+        QueryParameter.removeEmptyValue(params),
+        credentials,
+        baseUrl
       )
     )
   }
 
   def star(starForm: StarForm): ApiPrg[Response[NoContent]] =
     post[StarForm, NoContent](
-      HttpQuery("stars"),
+      HttpQuery(path = "stars", credentials = credentials, baseUrl = baseUrl),
       starForm
     )
+}
+
+object StarApi extends ApiContext[StarApi] {
+  override def apply(baseUrl: String, credentials: Credentials): StarApi =
+    new StarApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/StatusApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/StatusApi.scala
@@ -1,17 +1,29 @@
 package backlog4s.apis
 
-import backlog4s.datas.Status
+import backlog4s.datas.{Credentials, Status}
 import backlog4s.dsl.ApiDsl.ApiPrg
 import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object StatusApi {
+class StatusApi(override val baseUrl: String,
+                override val credentials: Credentials) extends Api {
 
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   val resource = "statuses"
 
   def all: ApiPrg[Response[Seq[Status]]] =
-    get[Seq[Status]](HttpQuery(resource))
+    get[Seq[Status]](
+      HttpQuery(
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
+}
+
+object StatusApi extends ApiContext[StatusApi] {
+  override def apply(baseUrl: String, credentials: Credentials): StatusApi =
+    new StatusApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/UserApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/UserApi.scala
@@ -6,34 +6,77 @@ import backlog4s.dsl.HttpADT.{ByteStream, Response}
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object UserApi {
+class UserApi(override val baseUrl: String,
+              override val credentials: Credentials) extends Api {
 
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   private val resource = "users"
 
-  def all(offset: Int = 0, limit: Int = 100): ApiPrg[Response[Seq[User]]] =
-    get[Seq[User]](HttpQuery(resource))
 
-  def byId(id: Id[User]): ApiPrg[Response[User]] =
+  // stream[A](() => ApiPrg[Response[Seq[A]]): Stream[IO, Seq[A]]
+  def all(offset: Int = 0, limit: Int = 100): ApiPrg[Response[Seq[User]]] =
+    get[Seq[User]](
+      HttpQuery(
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
+
+  def byId(id: Id[User]): ApiPrg[Response[User]] = {
+    val query = HttpQuery(
+      path = s"$resource/myself",
+      credentials = credentials,
+      baseUrl = baseUrl
+    )
     if (id == UserT.myself)
-      get[User](HttpQuery(s"$resource/myself"))
+      get[User](query)
     else
-      get[User](HttpQuery(s"$resource/${id.value}"))
+      get[User](query.copy(path = s"$resource/${id.value}"))
+  }
+
 
   def create(form: AddUserForm): ApiPrg[Response[User]] =
-    post[AddUserForm, User](HttpQuery(resource), form)
+    post[AddUserForm, User](
+      HttpQuery(
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
+      form
+    )
 
   def update(id: Id[User], form: UpdateUserForm): ApiPrg[Response[User]] =
     put[UpdateUserForm, User](
-      HttpQuery(s"$resource/${id.value}"),
+      HttpQuery(
+        path = s"$resource/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      ),
       form
     )
 
   def remove(id: Id[User]): ApiPrg[Response[Unit]] =
-    delete(HttpQuery(s"$resource/${id.value}"))
+    delete(
+      HttpQuery(
+        path = s"$resource/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 
   def downloadIcon(id: Id[User]): ApiPrg[Response[ByteStream]] =
-    download(HttpQuery(s"$resource/${id.value}/icon"))
+    download(
+      HttpQuery(
+        path = s"$resource/${id.value}/icon",
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
+    )
 }
 
+object UserApi extends ApiContext[UserApi] {
+  override def apply(baseUrl: String, credentials: Credentials): UserApi =
+    new UserApi(baseUrl, credentials)
+}

--- a/backlog4s-core/src/main/scala/backlog4s/apis/WatchingApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/WatchingApi.scala
@@ -10,7 +10,8 @@ import backlog4s.utils.QueryParameter
 import backlog4s.formatters.SprayJsonFormats._
 
 
-object WatchingApi {
+class WatchingApi(override val baseUrl: String,
+                  override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   val resource = "watchings"
@@ -31,7 +32,9 @@ object WatchingApi {
     get[Seq[Watching]](
       HttpQuery(
         s"users/${userId.value}/$resource",
-        QueryParameter.removeEmptyValue(params)
+        QueryParameter.removeEmptyValue(params),
+        credentials,
+        baseUrl
       )
     )
   }
@@ -48,7 +51,10 @@ object WatchingApi {
 
     get[Count](
       HttpQuery(
-        s"users/${userId.value}/$resource/count"
+        path = s"users/${userId.value}/$resource/count",
+        params,
+        credentials,
+        baseUrl
       )
     )
   }
@@ -56,14 +62,18 @@ object WatchingApi {
   def byId(id: Id[Watching]): ApiPrg[Response[Watching]] =
     get[Watching](
       HttpQuery(
-        s"$resource/${id.value}"
+        path = s"$resource/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def add(form: AddWatchingForm): ApiPrg[Response[Watching]] =
     post[AddWatchingForm, Watching](
       HttpQuery(
-        resource
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -71,7 +81,9 @@ object WatchingApi {
   def update(id: Id[Watching], note: String): ApiPrg[Response[Watching]] =
     put[CustomForm, Watching](
       HttpQuery(
-        s"$resource/${id.value}"
+        path = s"$resource/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       Map(
         "note" -> note
@@ -81,15 +93,24 @@ object WatchingApi {
   def remove(id: Id[Watching]): ApiPrg[Response[Unit]] =
     delete(
       HttpQuery(
-        s"$resource/${id.value}"
+        path = s"$resource/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def markAsRead(id: Id[Watching]): ApiPrg[Response[NoContent]] =
     post[CustomForm, NoContent](
       HttpQuery(
-        s"$resource/${id.value}/markAsRead"
+        path = s"$resource/${id.value}/markAsRead",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       Map()
     )
+}
+
+object WatchingApi extends ApiContext[WatchingApi] {
+  override def apply(baseUrl: String, credentials: Credentials): WatchingApi =
+    new WatchingApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/WebhookApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/WebhookApi.scala
@@ -6,7 +6,8 @@ import backlog4s.dsl.HttpADT.Response
 import backlog4s.dsl.HttpQuery
 import backlog4s.formatters.SprayJsonFormats._
 
-object WebhookApi {
+class WebhookApi(override val baseUrl: String,
+                 override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   def resource(projectIdOrKey: IdOrKeyParam[Project]): String =
@@ -14,14 +15,20 @@ object WebhookApi {
 
   def allOf(projectIdOrKey: IdOrKeyParam[Project]): ApiPrg[Response[Seq[Webhook]]] =
     get[Seq[Webhook]](
-      HttpQuery(resource(projectIdOrKey))
+      HttpQuery(
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
+      )
     )
 
   def add(projectIdOrKey: IdOrKeyParam[Project],
           form: AddWebhookForm): ApiPrg[Response[Webhook]] =
     post[AddWebhookForm, Webhook](
       HttpQuery(
-        resource(projectIdOrKey)
+        path = resource(projectIdOrKey),
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -31,7 +38,9 @@ object WebhookApi {
              form: UpdateWebhookForm): ApiPrg[Response[Webhook]] =
     put[UpdateWebhookForm, Webhook](
       HttpQuery(
-        s"${resource(projectIdOrKey)}/${id.value}"
+        path = s"${resource(projectIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -40,7 +49,14 @@ object WebhookApi {
              id: Id[Webhook]): ApiPrg[Response[Unit]] =
     delete(
       HttpQuery(
-        s"${resource(projectIdOrKey)}/${id.value}"
+        path = s"${resource(projectIdOrKey)}/${id.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
+}
+
+object WebhookApi extends ApiContext[WebhookApi] {
+  override def apply(baseUrl: String, credentials: Credentials): WebhookApi =
+    new WebhookApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/apis/WikiApi.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/apis/WikiApi.scala
@@ -7,7 +7,8 @@ import backlog4s.dsl.HttpQuery
 import cats.data.NonEmptyList
 import backlog4s.formatters.SprayJsonFormats._
 
-object WikiApi {
+class WikiApi(override val baseUrl: String,
+              override val credentials: Credentials) extends Api {
   import backlog4s.dsl.ApiDsl.HttpOp._
 
   val resource = "wikis"
@@ -18,7 +19,9 @@ object WikiApi {
         resource,
         Map(
           "projectIdOrKey" -> projectIdOrKey.toString
-        )
+        ),
+        credentials,
+        baseUrl
       )
     )
 
@@ -28,7 +31,9 @@ object WikiApi {
         s"$resource/count",
         Map(
           "projectIdOrKey" -> projectIdOrKey.toString
-        )
+        ),
+        credentials,
+        baseUrl
       )
     )
 
@@ -38,28 +43,36 @@ object WikiApi {
         s"$resource/tags",
         Map(
           "projectIdOrKey" -> projectIdOrKey.toString
-        )
+        ),
+        credentials,
+        baseUrl
       )
     )
 
   def attachments(id: Id[Wiki]): ApiPrg[Response[Seq[Attachment]]] =
     get[Seq[Attachment]](
       HttpQuery(
-        s"$resource/${id.value}/attachments"
+        path = s"$resource/${id.value}/attachments",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def downloadAttachment(id: Id[Wiki], attachmentId: Id[Attachment]): ApiPrg[Response[ByteStream]] =
     download(
       HttpQuery(
-        s"$resource/${id.value}/attachments/${attachmentId.value}"
+        path = s"$resource/${id.value}/attachments/${attachmentId.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def attach(id: Id[Wiki], attachmentIds: NonEmptyList[Id[Attachment]]): ApiPrg[Response[Attachment]] =
     post[AttachForm, Attachment](
       HttpQuery(
-        s"$resource/${id.value}/attachments"
+        path = s"$resource/${id.value}/attachments",
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       AttachForm(attachmentIds.toList)
     )
@@ -67,28 +80,36 @@ object WikiApi {
   def removeAttachment(id: Id[Wiki], attachmentId: Id[Attachment]): ApiPrg[Response[Unit]] =
     delete(
       HttpQuery(
-        s"$resource/${id.value}/attachments/${attachmentId.value}"
+        path = s"$resource/${id.value}/attachments/${attachmentId.value}",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def sharedFiles(id: Id[Wiki]): ApiPrg[Response[Seq[SharedFile]]] =
     get[Seq[SharedFile]](
       HttpQuery(
-        s"$resource/${id.value}/sharedFiles"
+        path = s"$resource/${id.value}/sharedFiles",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def history(id: Id[Wiki]): ApiPrg[Response[Seq[WikiHistory]]] =
     get[Seq[WikiHistory]](
       HttpQuery(
-        s"$resource/${id.value}/history"
+        path = s"$resource/${id.value}/history",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
   def stars(id: Id[Wiki]): ApiPrg[Response[Seq[Star]]] =
     get[Seq[Star]](
       HttpQuery(
-        s"$resource/${id.value}/stars"
+        path = s"$resource/${id.value}/stars",
+        credentials = credentials,
+        baseUrl = baseUrl
       )
     )
 
@@ -97,7 +118,9 @@ object WikiApi {
   def add(form: AddWikiForm): ApiPrg[Response[Wiki]] =
     post[AddWikiForm, Wiki](
       HttpQuery(
-        resource
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -105,7 +128,9 @@ object WikiApi {
   def update(id: Id[Wiki], form: UpdateWikiForm): ApiPrg[Response[Wiki]] =
     put[UpdateWikiForm, Wiki](
       HttpQuery(
-        resource
+        path = resource,
+        credentials = credentials,
+        baseUrl = baseUrl
       ),
       form
     )
@@ -116,7 +141,14 @@ object WikiApi {
         s"$resource/${id.value}",
         Map(
           "mailNotify" -> mailNotify.toString
-        )
+        ),
+        credentials,
+        baseUrl
       )
     )
+}
+
+object WikiApi extends ApiContext[WikiApi] {
+  override def apply(baseUrl: String, credentials: Credentials): WikiApi =
+    new WikiApi(baseUrl, credentials)
 }

--- a/backlog4s-core/src/main/scala/backlog4s/datas/Activity.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/datas/Activity.scala
@@ -56,5 +56,5 @@ case class ActivityChange(
   field: String,
   new_value: String,
   old_value: String,
-  `type`: String
+  `type`: Option[String]
 )

--- a/backlog4s-core/src/main/scala/backlog4s/dsl/HttpDsl.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/dsl/HttpDsl.scala
@@ -2,10 +2,11 @@ package backlog4s.dsl
 
 import java.nio.ByteBuffer
 import java.io.File
+
 import cats.effect.IO
 import cats.free.Free
 import cats.{InjectK, ~>}
-import backlog4s.datas.ApiErrors
+import backlog4s.datas.{ApiErrors, Credentials}
 import backlog4s.dsl.HttpADT.{ByteStream, Response}
 import spray.json.JsonFormat
 import fs2.Stream
@@ -22,7 +23,8 @@ object HttpADT {
 }
 
 sealed trait HttpADT[A]
-case class Get[A](query: HttpQuery, format: JsonFormat[A])
+case class Get[A](query: HttpQuery,
+                  format: JsonFormat[A])
   extends HttpADT[Response[A]]
 case class Post[Payload, A](
   query: HttpQuery,

--- a/backlog4s-core/src/main/scala/backlog4s/dsl/HttpQuery.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/dsl/HttpQuery.scala
@@ -1,11 +1,16 @@
 package backlog4s.dsl
 
+import backlog4s.datas.Credentials
+
 /**
   * Basic http query representation
+ *
   * @param path a pathname /users for example
   * @param params a list of query parameters
   */
 case class HttpQuery(
   path: String,
-  params: Map[String, String] = Map()
+  params: Map[String, String] = Map(),
+  credentials: Credentials,
+  baseUrl: String
 )

--- a/backlog4s-core/src/main/scala/backlog4s/dsl/syntax.scala
+++ b/backlog4s-core/src/main/scala/backlog4s/dsl/syntax.scala
@@ -27,4 +27,25 @@ object syntax {
         case Left(error) => throw BacklogApiException(error)
       }
   }
+
+  implicit class ApiSeqOps[A](apiPrg: Seq[ApiPrg[A]]) {
+    // Allow to run a sequence of operation
+    // This is not running in parallel still sequential
+    // I need to study about combining Free monad and Free applicative
+    // To understand how can i run multiple program step in parallel
+    // Also i want to keep the syntax of writing Api program
+    // as simple as possible the performance cost will be here
+    // important because we will not be able to exploit multiple cores
+    // to dispatch multiple api request at the same time
+    // For now this is an enough solution
+    def sequence: ApiPrg[Seq[A]] =
+      apiPrg.foldLeft(pure(Seq.empty[A])) {
+        case (newPrg, prg) =>
+          newPrg.flatMap { results =>
+            prg.map { result =>
+              results :+ result
+            }
+          }
+      }
+  }
 }

--- a/backlog4s-test/src/main/scala/App.scala
+++ b/backlog4s-test/src/main/scala/App.scala
@@ -25,10 +25,9 @@ object App {
 
     val httpInterpret = new AkkaHttpInterpret
     val interpreter = httpInterpret
-    val accessKey = ApiKey.accessKey
-    val api = AllApi.accessKey(baseUrl, accessKey)
+    val allApi = AllApi.accessKey(baseUrl, ApiKey.accessKey)
 
-    import api._
+    import allApi._
 
     val prg = for {
       projects <- projectApi.all().orFail
@@ -49,8 +48,7 @@ object App {
       countIssues <- issueApi.count().orFail
       activities <- activityApi.space
       repositories <- gitApi.allOf(IdParam(projects.head.id)).orFail
-      webhooks <- webhookApi.allOf(IdParam(projects.head.id)).orFail
-    } yield webhooks
+    } yield repositories
 
     val prg2 = userApi.create(
       AddUserForm(


### PR DESCRIPTION
Removed access key and base url from interpreter. Now interpreter just run the http request. It add a little bit more boilerplate for the user. But now it's easier to use backlog4s when using multiple spaces and different credentials