### PR TITLE
Remove Content-Type from headers

### DIFF
--- a/backlog4s-akka/src/main/scala/backlog4s/interpreters/AkkaHttpInterpret.scala
+++ b/backlog4s-akka/src/main/scala/backlog4s/interpreters/AkkaHttpInterpret.scala
@@ -36,7 +36,6 @@ class AkkaHttpInterpret(implicit actorSystem: ActorSystem, mat: Materializer,
   private val maxRedirCount = 20
   private val reqHeaders: Seq[HttpHeader] = Seq(
     headers.`User-Agent`("backlog4s"),
-    headers.`Content-Type`(ContentTypes.`application/json`),
     headers.`Accept-Charset`(HttpCharsets.`UTF-8`)
   )
 


### PR DESCRIPTION
`Content-Type` header is not allowed.
```
[WARN] [02/06/2018 15:32:23.299] [demo-akka.actor.default-dispatcher-13] [akka.actor.ActorSystemImpl(demo)] Explicitly set HTTP header 'Content-Type: application/json' is ignored, explicit `Content-Type` header is not allowed. Set `HttpRequest.entity.contentType` instead.
```