### PR TITLE
Support vim, metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ project/plugins/project/
 .cache
 .lib/
 .idea
+
+# metals
+.bsp
+.bloop
+.metals
+metals.sbt


### PR DESCRIPTION
Add ignore entries to .gitignore to use `coc-metals` (nvim extension)

https://scalameta.org/metals/docs/editors/vim.html